### PR TITLE
Fix widget getting hidden

### DIFF
--- a/taggit_labels/widgets.py
+++ b/taggit_labels/widgets.py
@@ -21,6 +21,10 @@ class LabelWidget(forms.TextInput):
             model = Tag
         self.model = model
         super(LabelWidget, self).__init__(*args, **kwargs)
+        
+    @property
+    def is_hidden(self):
+        return False
 
     def tag_list(self, tags):
         """


### PR DESCRIPTION
Since the commit in django below, widgets with input_type hidden are hidden entirely.
Override is_hidden to prevent this from happening.

Affects Django version v1.7 and up.

https://github.com/django/django/commit/dc3d2ac98c1bcfad74d3e9523caf07e7e9fb15aa