### PR TITLE
Fix overloading model via subclass

### DIFF
--- a/taggit_labels/widgets.py
+++ b/taggit_labels/widgets.py
@@ -3,6 +3,7 @@ from django.forms.util import flatatt
 from django.utils.safestring import mark_safe
 from django.utils import six
 
+from taggit.models import Tag
 from taggit.utils import edit_string_for_tags
 
 
@@ -12,16 +13,12 @@ class LabelWidget(forms.TextInput):
     selectable labels.
     """
     input_type = 'hidden'
-    model = None
+    model = Tag
 
     def __init__(self, *args, **kwargs):
-        model = kwargs.pop('model', None)
-        if model is None:
-            from taggit.models import Tag
-            model = Tag
-        self.model = model
+        self.model = kwargs.pop('model', None) or self.model
         super(LabelWidget, self).__init__(*args, **kwargs)
-        
+
     @property
     def is_hidden(self):
         return False


### PR DESCRIPTION
Previous code only used model from kwarg or default Tag model, overwriting self.model (from the class) in any case.