### PR TITLE
Fix rendering selected tags

### DIFF
--- a/taggit_labels/widgets.py
+++ b/taggit_labels/widgets.py
@@ -71,7 +71,7 @@ class LabelWidget(forms.TextInput):
             attrs.update({'class': 'taggit-labels taggit-list'})
         list_attrs = flatatt(attrs)
 
-        tag_li = "".join([u"<li data-tag-name='{0}' class={1}>{0}</li>".format(
+        tag_li = "".join([u"<li data-tag-name='{0}' class='{1}'>{0}</li>".format(
             tag[0], tag[1]) for tag in selected_tags])
         tag_ul = u"<ul{0}>{1}</ul>".format(list_attrs, tag_li)
         return mark_safe(u"{0}{1}".format(tag_ul, input_field))


### PR DESCRIPTION
Because the class wasn't in quotes, `class=selected taggit-tag` was interpreted by the browser as `class="selected" taggit-tag=""` and didn't work.